### PR TITLE
Put the filetype.vim within a ftdetect so that there is no need to move it to ~/.vim/

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -1,9 +1,0 @@
-" my filetype file
-if exists("did_load_filetypes")
-  finish
-endif
-augroup filetypedetect
-  au! BufRead,BufNewFile *.k		setfiletype k
-  au! BufRead,BufNewFile *.q		setfiletype q
-  au! BufRead,BufNewFile *.s		setfiletype sql
-augroup END

--- a/ftdetect/filetype.vim
+++ b/ftdetect/filetype.vim
@@ -1,0 +1,3 @@
+au! BufRead,BufNewFile *.k		setfiletype k
+au! BufRead,BufNewFile *.q		setfiletype q
+au! BufRead,BufNewFile *.s      setfiletype sql

--- a/ftdetect/filetype.vim
+++ b/ftdetect/filetype.vim
@@ -1,3 +1,3 @@
-au! BufRead,BufNewFile *.k		setfiletype k
-au! BufRead,BufNewFile *.q		setfiletype q
-au! BufRead,BufNewFile *.s      setfiletype sql
+au! BufRead,BufNewFile *.k setfiletype k
+au! BufRead,BufNewFile *.q setfiletype q
+au! BufRead,BufNewFile *.s setfiletype sql


### PR DESCRIPTION
If the filetype.vim was in a ftdetect dir there would be no need to move it.
